### PR TITLE
feat(user-profile): allow sending arbitrary data on profile

### DIFF
--- a/packages/user-profile/package.json
+++ b/packages/user-profile/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@2060.io/credo-ts-user-profile",
+  "name": "@2060.io/credo-ts-didcomm-user-profile",
   "main": "build/index",
   "types": "build/index",
   "version": "0.0.1",

--- a/packages/user-profile/src/UserProfileApi.ts
+++ b/packages/user-profile/src/UserProfileApi.ts
@@ -47,7 +47,7 @@ export class UserProfileApi {
    */
   public async sendUserProfile(options: {
     connectionId: string
-    profileData?: Partial<UserProfileData>
+    profileData?: Partial<UserProfileData> | Record<string, unknown>
     sendBackYours?: boolean
   }) {
     const { connectionId, profileData, sendBackYours } = options

--- a/packages/user-profile/src/messages/ProfileMessage.ts
+++ b/packages/user-profile/src/messages/ProfileMessage.ts
@@ -2,13 +2,21 @@ import { AgentMessage, Attachment, IsValidMessageType, parseMessageType } from '
 import { Expose } from 'class-transformer'
 import { IsBoolean, IsOptional } from 'class-validator'
 
-import { UserProfile, UserProfileData } from '../model'
+import { PictureData, UserProfileData } from '../model'
 
 export interface ProfileMessageOptions {
   id?: string
-  profile: Partial<UserProfileData>
+  profile: Partial<UserProfileData> | Record<string, unknown>
   threadId?: string
   sendBackYours?: boolean
+}
+
+class ProfileForExchange {
+  public displayName?: string
+  public displayPicture?: string
+  public displayIcon?: string
+  public description?: string
+  public preferredLanguage?: string
 }
 
 export class ProfileMessage extends AgentMessage {
@@ -27,14 +35,15 @@ export class ProfileMessage extends AgentMessage {
       }
 
       if (options.profile.displayPicture) {
+        const pictureData = options.profile.displayPicture as PictureData
         // If there is a display picture, we need to add an attachment including picture data
         this.addAppendedAttachment(
           new Attachment({
             id: 'displayPicture',
-            mimeType: options.profile.displayPicture.mimeType,
+            mimeType: pictureData.mimeType,
             data: {
-              base64: options.profile.displayPicture.base64,
-              links: options.profile.displayPicture.links,
+              base64: pictureData.base64,
+              links: pictureData.links,
             },
           }),
         )
@@ -42,13 +51,14 @@ export class ProfileMessage extends AgentMessage {
 
       if (options.profile.displayIcon) {
         // If there is a display icon, we need to add an attachment including picture data
+        const pictureData = options.profile.displayIcon as PictureData
         this.addAppendedAttachment(
           new Attachment({
             id: 'displayIcon',
-            mimeType: options.profile.displayIcon.mimeType,
+            mimeType: pictureData.mimeType,
             data: {
-              base64: options.profile.displayIcon.base64,
-              links: options.profile.displayIcon.links,
+              base64: pictureData.base64,
+              links: pictureData.links,
             },
           }),
         )
@@ -62,7 +72,7 @@ export class ProfileMessage extends AgentMessage {
   public readonly type = ProfileMessage.type.messageTypeUri
   public static readonly type = parseMessageType('https://didcomm.org/user-profile/1.0/profile')
 
-  public profile!: UserProfile
+  public profile!: ProfileForExchange | Record<string, unknown>
 
   @IsOptional()
   @IsBoolean()

--- a/packages/user-profile/src/messages/RequestProfileMessage.ts
+++ b/packages/user-profile/src/messages/RequestProfileMessage.ts
@@ -1,14 +1,14 @@
 import { AgentMessage, IsValidMessageType, parseMessageType } from '@credo-ts/core'
 
-import { UserProfile } from '../model'
+import { UserProfileData } from '../model'
+
+export type UserProfileKey = string | keyof UserProfileData
 
 export interface GetProfileMessageOptions {
   id?: string
   threadId?: string
-  query?: ConnectionProfileKey[]
+  query?: UserProfileKey[]
 }
-
-export type ConnectionProfileKey = keyof UserProfile
 
 export class RequestProfileMessage extends AgentMessage {
   public constructor(options?: GetProfileMessageOptions) {
@@ -27,5 +27,5 @@ export class RequestProfileMessage extends AgentMessage {
   public readonly type = RequestProfileMessage.type.messageTypeUri
   public static readonly type = parseMessageType('https://didcomm.org/user-profile/1.0/request-profile')
 
-  public query?: ConnectionProfileKey[]
+  public query?: UserProfileKey[]
 }

--- a/packages/user-profile/src/model/ConnectionMetadata.ts
+++ b/packages/user-profile/src/model/ConnectionMetadata.ts
@@ -4,5 +4,5 @@ import type { ConnectionRecord } from '@credo-ts/core'
 export const getConnectionProfile = (record: ConnectionRecord) =>
   record.metadata.get('UserProfile') as UserProfileData | null
 
-export const setConnectionProfile = (record: ConnectionRecord, metadata: UserProfileData) =>
+export const setConnectionProfile = (record: ConnectionRecord, metadata: UserProfileData | Record<string, unknown>) =>
   record.metadata.add('UserProfile', metadata)

--- a/packages/user-profile/src/model/UserProfile.ts
+++ b/packages/user-profile/src/model/UserProfile.ts
@@ -9,21 +9,5 @@ export interface UserProfileData {
   displayPicture?: PictureData
   displayIcon?: PictureData
   description?: string
-  organizationDid?: string
-  organizationName?: string
-  registrarDid?: string
-  registrarName?: string
-}
-
-export class UserProfile {
-  public type?: string
-  public category?: string
-  public displayName?: string
-  public displayPicture?: string
-  public displayIcon?: string
-  public description?: string
-  public organizationDid?: string
-  public organizationName?: string
-  public registrarDid?: string
-  public registrarName?: string
+  preferredLanguage?: string
 }

--- a/packages/user-profile/src/repository/UserProfileRecord.ts
+++ b/packages/user-profile/src/repository/UserProfileRecord.ts
@@ -12,6 +12,7 @@ export class UserProfileRecord extends BaseRecord implements UserProfileStorageP
   public displayName?: string
   public displayPicture?: PictureData
   public description?: string
+  public preferredLanguage?: string
 
   public static readonly type = 'UserProfileRecord'
   public readonly type = UserProfileRecord.type
@@ -25,6 +26,7 @@ export class UserProfileRecord extends BaseRecord implements UserProfileStorageP
       this.displayName = props.displayName
       this.displayPicture = props.displayPicture
       this.description = props.description
+      this.preferredLanguage = props.preferredLanguage
     }
   }
 

--- a/packages/user-profile/src/services/UserProfileEvents.ts
+++ b/packages/user-profile/src/services/UserProfileEvents.ts
@@ -1,4 +1,4 @@
-import type { ConnectionProfileKey } from '../messages'
+import type { UserProfileKey } from '../messages'
 import type { UserProfileData } from '../model'
 import type { UserProfileRecord } from '../repository'
 import type { BaseEvent, ConnectionRecord } from '@credo-ts/core'
@@ -13,7 +13,7 @@ export interface UserProfileRequestedEvent extends BaseEvent {
   type: ProfileEventTypes.UserProfileRequested
   payload: {
     connection: ConnectionRecord
-    query?: ConnectionProfileKey[]
+    query?: UserProfileKey[]
   }
 }
 

--- a/packages/user-profile/test/profile.test.ts
+++ b/packages/user-profile/test/profile.test.ts
@@ -8,6 +8,7 @@ import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
 import { filter, firstValueFrom, map, Subject, timeout } from 'rxjs'
 
 import { UserProfileModule } from '../src/UserProfileModule'
+import { getConnectionProfile } from '../src/model'
 import { ProfileEventTypes } from '../src/services'
 
 import { SubjectInboundTransport } from './transport/SubjectInboundTransport'
@@ -152,6 +153,7 @@ describe('profile test', () => {
       profileData: {
         displayIcon: { base64: 'base64' },
         organizationDid: 'orgDid',
+        whatever: 'I want',
       },
       sendBackYours: false,
     })
@@ -161,6 +163,15 @@ describe('profile test', () => {
     expect(profile).toEqual(
       expect.objectContaining({
         organizationDid: 'orgDid',
+        whatever: 'I want',
+        displayIcon: { base64: 'base64' },
+      }),
+    )
+
+    expect(getConnectionProfile(await aliceAgent.connections.getById(aliceConnectionRecord.id))).toEqual(
+      expect.objectContaining({
+        organizationDid: 'orgDid',
+        whatever: 'I want',
         displayIcon: { base64: 'base64' },
       }),
     )


### PR DESCRIPTION
First step on allowing extensions for User Profile over the already known fields. However, we are still saving an "UserProfileRecord" that has some fixed fields on it.

For the moment, we are adding here a 'preferredLanguage' to speed up testing of Unic.ID PoC.