### PR TITLE
fix(calls): snake_case parameters and time serialization

### DIFF
--- a/packages/calls/src/messages/CallOfferMessage.ts
+++ b/packages/calls/src/messages/CallOfferMessage.ts
@@ -1,5 +1,7 @@
 import { AgentMessage, IsValidMessageType, parseMessageType } from '@credo-ts/core'
-import { IsString } from 'class-validator'
+import { DateTransformer } from '@credo-ts/core/build/utils/transformers'
+import { Expose } from 'class-transformer'
+import { IsDate, IsString } from 'class-validator'
 
 export type DidCommCallType = 'audio' | 'video' | 'service'
 
@@ -27,10 +29,17 @@ export class CallOfferMessage extends AgentMessage {
   }
 
   @IsString()
+  @Expose({ name: 'call_type' })
   public callType!: string
 
+  @IsDate()
+  @Expose({ name: 'offer_expiration_time' })
+  @DateTransformer()
   public offerExpirationTime?: Date | null
 
+  @IsDate()
+  @DateTransformer()
+  @Expose({ name: 'offer_start_time' })
   public offerStartTime?: Date | null
 
   public description?: string

--- a/packages/calls/tests/DidCommCallsService.test.ts
+++ b/packages/calls/tests/DidCommCallsService.test.ts
@@ -27,6 +27,8 @@ describe('Didcomm Calls', () => {
       const message = didcommCallsService.createOffer({
         callType: 'video',
         description: 'new Call Offer',
+        offerStartTime: new Date('2024-12-02T01:26:02Z'),
+        offerExpirationTime: new Date('2024-12-02T01:26:03.070Z'),
         parameters: { param: 'value' },
       })
 
@@ -36,7 +38,10 @@ describe('Didcomm Calls', () => {
         expect.objectContaining({
           '@id': expect.any(String),
           '@type': 'https://didcomm.org/calls/1.0/call-offer',
-          callType: 'video',
+          description: 'new Call Offer',
+          call_type: 'video',
+          offer_start_time: '2024-12-02T01:26:02.000Z',
+          offer_expiration_time: '2024-12-02T01:26:03.070Z',
           parameters: { param: 'value' },
         }),
       )


### PR DESCRIPTION
- Changed call-offer parameters to use snake_case instead of camelCase, to follow DIDComm conventions as exposed in [DIDComm Best practices](https://github.com/hyperledger/aries-rfcs/tree/main/concepts/0074-didcomm-best-practices#snake_case-and-variants)
- Likewise, some updates to offer_*_time transformation in order to follow [this convention](https://github.com/hyperledger/aries-rfcs/tree/main/concepts/0074-didcomm-best-practices#_time)