### PR TITLE
fix(mrtd): return disclosures for sync requests

### DIFF
--- a/packages/mrtd/package.json
+++ b/packages/mrtd/package.json
@@ -43,6 +43,7 @@
     "class-validator": "0.14.1",
     "esbuild": "^0.24.0",
     "mrz": "^4.2.0",
+    "reflect-metadata": "^0.1.13",   
     "rxjs": "^7.2.0",
     "tsyringe": "^4.8.0"
   }

--- a/packages/mrtd/package.json
+++ b/packages/mrtd/package.json
@@ -43,6 +43,7 @@
     "class-validator": "0.14.1",
     "esbuild": "^0.24.0",
     "mrz": "^4.2.0",
+    "rxjs": "^7.2.0",
     "tsyringe": "^4.8.0"
   }
 }

--- a/packages/mrtd/package.json
+++ b/packages/mrtd/package.json
@@ -43,7 +43,7 @@
     "class-validator": "0.14.1",
     "esbuild": "^0.24.0",
     "mrz": "^4.2.0",
-    "reflect-metadata": "^0.1.13",   
+    "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "tsyringe": "^4.8.0"
   }

--- a/packages/mrtd/tests/mrtd.e2e.test.ts
+++ b/packages/mrtd/tests/mrtd.e2e.test.ts
@@ -1,0 +1,139 @@
+import type { ConnectionRecord, EncryptedMessage } from '@credo-ts/core'
+
+import { AskarModule } from '@credo-ts/askar'
+import { Agent, ConsoleLogger, DidExchangeState, LogLevel, utils } from '@credo-ts/core'
+import { agentDependencies } from '@credo-ts/node'
+import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
+import { Subject } from 'rxjs'
+
+import { DidCommMrtdModule } from '../src/DidCommMrtdModule'
+
+import { SubjectInboundTransport } from './transport/SubjectInboundTransport'
+import { SubjectOutboundTransport } from './transport/SubjectOutboundTransport'
+
+const logger = new ConsoleLogger(LogLevel.off)
+
+export type SubjectMessage = { message: EncryptedMessage; replySubject?: Subject<SubjectMessage> }
+
+describe('profile test', () => {
+  let aliceAgent: Agent<{ askar: AskarModule; mrtd: DidCommMrtdModule }>
+  let bobAgent: Agent<{ askar: AskarModule; mrtd: DidCommMrtdModule }>
+  let aliceWalletId: string
+  let aliceWalletKey: string
+  let bobWalletId: string
+  let bobWalletKey: string
+  let aliceConnectionRecord: ConnectionRecord
+  let bobConnectionRecord: ConnectionRecord
+
+  beforeEach(async () => {
+    aliceWalletId = utils.uuid()
+    aliceWalletKey = utils.uuid()
+    bobWalletId = utils.uuid()
+    bobWalletKey = utils.uuid()
+
+    const aliceMessages = new Subject<SubjectMessage>()
+    const bobMessages = new Subject<SubjectMessage>()
+
+    const subjectMap = {
+      'rxjs:alice': aliceMessages,
+      'rxjs:bob': bobMessages,
+    }
+
+    // Initialize alice
+    aliceAgent = new Agent({
+      config: {
+        label: 'alice',
+        endpoints: ['rxjs:alice'],
+        walletConfig: { id: aliceWalletId, key: aliceWalletKey },
+        logger,
+      },
+      dependencies: agentDependencies,
+      modules: { askar: new AskarModule({ ariesAskar }), mrtd: new DidCommMrtdModule() },
+    })
+
+    aliceAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    aliceAgent.registerInboundTransport(new SubjectInboundTransport(aliceMessages))
+    await aliceAgent.initialize()
+
+    // Initialize bob
+    bobAgent = new Agent({
+      config: {
+        endpoints: ['rxjs:bob'],
+        label: 'bob',
+        walletConfig: { id: bobWalletId, key: bobWalletKey },
+        logger,
+      },
+      dependencies: agentDependencies,
+      modules: { askar: new AskarModule({ ariesAskar }), mrtd: new DidCommMrtdModule() },
+    })
+
+    bobAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    bobAgent.registerInboundTransport(new SubjectInboundTransport(bobMessages))
+    await bobAgent.initialize()
+
+    const outOfBandRecord = await aliceAgent.oob.createInvitation({
+      autoAcceptConnection: true,
+    })
+
+    const { connectionRecord } = await bobAgent.oob.receiveInvitationFromUrl(
+      outOfBandRecord.outOfBandInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      { autoAcceptConnection: true },
+    )
+
+    bobConnectionRecord = await bobAgent.connections.returnWhenIsConnected(connectionRecord!.id)
+    expect(bobConnectionRecord.state).toBe(DidExchangeState.Completed)
+
+    aliceConnectionRecord = (await aliceAgent.connections.findAllByOutOfBandId(outOfBandRecord.id))[0]
+    aliceConnectionRecord = await aliceAgent.connections.returnWhenIsConnected(aliceConnectionRecord!.id)
+    expect(aliceConnectionRecord.state).toBe(DidExchangeState.Completed)
+  })
+
+  afterEach(async () => {
+    // Wait for messages to flush out
+    await new Promise((r) => setTimeout(r, 1000))
+
+    if (aliceAgent) {
+      await aliceAgent.shutdown()
+
+      if (aliceAgent.wallet.isInitialized && aliceAgent.wallet.isProvisioned) {
+        await aliceAgent.wallet.delete()
+      }
+    }
+
+    if (bobAgent) {
+      await bobAgent.shutdown()
+
+      if (bobAgent.wallet.isInitialized && bobAgent.wallet.isProvisioned) {
+        await bobAgent.wallet.delete()
+      }
+    }
+  })
+
+  test('Set and query an NFC support', async () => {
+    // Bob requests MRTD capabilities. eMRTD read support is false, since it is not set
+    let response = await bobAgent.modules.mrtd.requestMrtdCapabilities({
+      connectionId: bobConnectionRecord.id,
+      awaitDisclosure: true,
+    })
+    expect(response.eMrtdReadSupported).toBeFalsy()
+
+    // Alice sets eMRTD read support. When Bob queries for it, he should get a true value
+    await aliceAgent.modules.mrtd.setMrtdCapabilities({ eMrtdReadSupported: true })
+
+    response = await bobAgent.modules.mrtd.requestMrtdCapabilities({
+      connectionId: bobConnectionRecord.id,
+      awaitDisclosure: true,
+    })
+    expect(response.eMrtdReadSupported).toBeTruthy()
+
+    // Alice now sets eMRTD read support to false. When Bob queries for it, he should get a false value
+
+    await aliceAgent.modules.mrtd.setMrtdCapabilities({ eMrtdReadSupported: false })
+
+    response = await bobAgent.modules.mrtd.requestMrtdCapabilities({
+      connectionId: bobConnectionRecord.id,
+      awaitDisclosure: true,
+    })
+    expect(response.eMrtdReadSupported).toBeFalsy()
+  })
+})

--- a/packages/mrtd/tests/recordUtils.ts
+++ b/packages/mrtd/tests/recordUtils.ts
@@ -1,0 +1,87 @@
+import type {
+  BaseRecord,
+  RecordSavedEvent,
+  RecordDeletedEvent,
+  RecordUpdatedEvent,
+  Agent,
+  BaseEvent,
+} from '@credo-ts/core'
+import type { Constructor } from '@credo-ts/core/build/utils/mixins'
+
+import { RepositoryEventTypes } from '@credo-ts/core'
+import { map, filter, pipe } from 'rxjs'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type BaseRecordAny = BaseRecord<any, any, any>
+type RecordClass<R extends BaseRecordAny> = Constructor<R> & { type: string }
+export interface RecordsState<R extends BaseRecordAny> {
+  loading: boolean
+  records: R[]
+}
+
+export const addRecord = <R extends BaseRecordAny>(record: R, state: RecordsState<R>): RecordsState<R> => {
+  const newRecordsState = [...state.records]
+  newRecordsState.unshift(record)
+  return {
+    loading: state.loading,
+    records: newRecordsState,
+  }
+}
+
+export const updateRecord = <R extends BaseRecordAny>(record: R, state: RecordsState<R>): RecordsState<R> => {
+  const newRecordsState = [...state.records]
+  const index = newRecordsState.findIndex((r) => r.id === record.id)
+  if (index > -1) {
+    newRecordsState[index] = record
+  }
+  return {
+    loading: state.loading,
+    records: newRecordsState,
+  }
+}
+
+export const removeRecord = <R extends BaseRecordAny>(record: R, state: RecordsState<R>): RecordsState<R> => {
+  const newRecordsState = state.records.filter((r) => r.id !== record.id)
+  return {
+    loading: state.loading,
+    records: newRecordsState,
+  }
+}
+
+const filterByType = <R extends BaseRecordAny>(recordClass: RecordClass<R>) => {
+  return pipe(
+    map((event: BaseEvent) => (event.payload as Record<string, R>).record),
+    filter((record: R) => record.type === recordClass.type),
+  )
+}
+
+export const recordsAddedByType = <R extends BaseRecordAny>(agent: Agent | undefined, recordClass: RecordClass<R>) => {
+  if (!agent) {
+    throw new Error('Agent is required to subscribe to events')
+  }
+  return agent?.events.observable<RecordSavedEvent<R>>(RepositoryEventTypes.RecordSaved).pipe(filterByType(recordClass))
+}
+
+export const recordsUpdatedByType = <R extends BaseRecordAny>(
+  agent: Agent | undefined,
+  recordClass: RecordClass<R>,
+) => {
+  if (!agent) {
+    throw new Error('Agent is required to subscribe to events')
+  }
+  return agent?.events
+    .observable<RecordUpdatedEvent<R>>(RepositoryEventTypes.RecordUpdated)
+    .pipe(filterByType(recordClass))
+}
+
+export const recordsRemovedByType = <R extends BaseRecordAny>(
+  agent: Agent | undefined,
+  recordClass: RecordClass<R>,
+) => {
+  if (!agent) {
+    throw new Error('Agent is required to subscribe to events')
+  }
+  return agent?.events
+    .observable<RecordDeletedEvent<R>>(RepositoryEventTypes.RecordDeleted)
+    .pipe(filterByType(recordClass))
+}

--- a/packages/mrtd/tests/setup.ts
+++ b/packages/mrtd/tests/setup.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata'

--- a/packages/mrtd/tests/transport/SubjectInboundTransport.ts
+++ b/packages/mrtd/tests/transport/SubjectInboundTransport.ts
@@ -1,0 +1,69 @@
+import type { Agent, AgentContext, EncryptedMessage, InboundTransport, TransportSession } from '@credo-ts/core'
+import type { Subscription } from 'rxjs'
+
+import { MessageReceiver, TransportService, utils } from '@credo-ts/core'
+import { Subject } from 'rxjs'
+
+export type SubjectMessage = { message: EncryptedMessage; replySubject?: Subject<SubjectMessage> }
+
+export class SubjectInboundTransport implements InboundTransport {
+  public readonly ourSubject: Subject<SubjectMessage>
+  private subscription?: Subscription
+
+  public constructor(ourSubject = new Subject<SubjectMessage>()) {
+    this.ourSubject = ourSubject
+  }
+
+  public async start(agent: Agent) {
+    this.subscribe(agent)
+  }
+
+  public async stop() {
+    this.subscription?.unsubscribe()
+  }
+
+  private subscribe(agent: Agent) {
+    const logger = agent.config.logger
+    const transportService = agent.dependencyManager.resolve(TransportService)
+    const messageReceiver = agent.dependencyManager.resolve(MessageReceiver)
+
+    this.subscription = this.ourSubject.subscribe({
+      next: async ({ message, replySubject }: SubjectMessage) => {
+        logger.test('Received message')
+
+        let session: SubjectTransportSession | undefined
+        if (replySubject) {
+          session = new SubjectTransportSession(`subject-session-${utils.uuid()}`, replySubject)
+
+          // When the subject is completed (e.g. when the session is closed), we need to
+          // remove the session from the transport service so it won't be used for sending messages
+          // in the future.
+          replySubject.subscribe({
+            complete: () => session && transportService.removeSession(session),
+          })
+        }
+
+        await messageReceiver.receiveMessage(message, { session })
+      },
+    })
+  }
+}
+
+export class SubjectTransportSession implements TransportSession {
+  public id: string
+  public readonly type = 'subject'
+  private replySubject: Subject<SubjectMessage>
+
+  public constructor(id: string, replySubject: Subject<SubjectMessage>) {
+    this.id = id
+    this.replySubject = replySubject
+  }
+
+  public async send(agentContext: AgentContext, encryptedMessage: EncryptedMessage): Promise<void> {
+    this.replySubject.next({ message: encryptedMessage })
+  }
+
+  public async close(): Promise<void> {
+    this.replySubject.complete()
+  }
+}

--- a/packages/mrtd/tests/transport/SubjectOutboundTransport.ts
+++ b/packages/mrtd/tests/transport/SubjectOutboundTransport.ts
@@ -1,0 +1,62 @@
+import type { SubjectMessage } from './SubjectInboundTransport'
+import type { OutboundPackage, OutboundTransport, Agent, Logger } from '@credo-ts/core'
+
+import { MessageReceiver, InjectionSymbols, CredoError } from '@credo-ts/core'
+import { takeUntil, Subject, take } from 'rxjs'
+
+export class SubjectOutboundTransport implements OutboundTransport {
+  private logger!: Logger
+  private subjectMap: { [key: string]: Subject<SubjectMessage> | undefined }
+  private agent!: Agent
+  private stop$!: Subject<boolean>
+
+  public supportedSchemes = ['rxjs', 'wss']
+
+  public constructor(subjectMap: { [key: string]: Subject<SubjectMessage> | undefined }) {
+    this.subjectMap = subjectMap
+  }
+
+  public async start(agent: Agent): Promise<void> {
+    this.agent = agent
+
+    this.logger = agent.dependencyManager.resolve(InjectionSymbols.Logger)
+    this.stop$ = agent.dependencyManager.resolve(InjectionSymbols.Stop$)
+  }
+
+  public async stop(): Promise<void> {
+    // No logic needed
+  }
+
+  public async sendMessage(outboundPackage: OutboundPackage) {
+    const messageReceiver = this.agent.dependencyManager.resolve(MessageReceiver)
+    this.logger.debug(`Sending outbound message to endpoint ${outboundPackage.endpoint}`, {
+      endpoint: outboundPackage.endpoint,
+    })
+    const { payload, endpoint } = outboundPackage
+
+    if (!endpoint) {
+      throw new CredoError('Cannot send message to subject without endpoint')
+    }
+
+    const subject = this.subjectMap[endpoint]
+
+    if (!subject) {
+      throw new CredoError(`No subject found for endpoint ${endpoint}`)
+    }
+
+    // Create a replySubject just for this session. Both ends will be able to close it,
+    // mimicking a transport like http or websocket. Close session automatically when agent stops
+    const replySubject = new Subject<SubjectMessage>()
+    this.stop$.pipe(take(1)).subscribe(() => !replySubject.closed && replySubject.complete())
+
+    replySubject.pipe(takeUntil(this.stop$)).subscribe({
+      next: async ({ message }: SubjectMessage) => {
+        this.logger.test('Received message')
+
+        await messageReceiver.receiveMessage(message)
+      },
+    })
+
+    subject.next({ message: payload, replySubject })
+  }
+}


### PR DESCRIPTION
`requestEMrtdCapabilities` was not returning the disclosure when running in sync mode, making it unusable in practice. Here we fix that and also some other good things:

- Rename `requestEMrdtCapabilities` to `requestMrdtCapabilities` (without 'E'). Same thing with the setter
- Support dynamically changing capabilities' values without the need of re-instancing the Agent 
- Add E2E test for MRTD capability query and disclosure