### PR TITLE
fix(mrtd): lint errors and dependencies

### DIFF
--- a/packages/mrtd/docs/mrtd-authenticity-integrity.md
+++ b/packages/mrtd/docs/mrtd-authenticity-integrity.md
@@ -19,19 +19,16 @@ This module adds authenticity and integrity verification for electronic Machine 
 ## Architecture (high level)
 
 - **`CscaMasterListService`**
-
   - Lazily resolves `DidCommMrtdModuleConfig` and `FileSystem` inside `initialize()`.
   - If `masterListCscaLocation` is an **HTTP(S) URL**, downloads once to `FileSystem.cachePath` and reuses the cached file. If the file already exists, it is re‑used; otherwise it downloads and caches it.
   - Extracts all CSCA certificates from the LDIF Master List into an internal trust store.
 
 - **`SodVerifierService`**
-
   - Depends on `CscaMasterListService`.
   - `verifySod(sodBuffer: Buffer, dataGroups: Record<string, Buffer>)` → `{ authenticity, integrity, details? }`.
   - Parses SOD (CMS SignedData), extracts LDS hashes, checks DG integrity, and validates DSC chain against CSCA anchors.
 
 - **`DidCommMrtdService`**
-
   - `processEMrtdData(...)` parses base64 DGs, ensures the Master List is initialized once, delegates SOD verification to `SodVerifierService`, then emits `EMrtdDataReceived` with both parsed fields and the verification outcome.
   - Event payload shape:
 

--- a/packages/mrtd/package.json
+++ b/packages/mrtd/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@li0ard/tsemrtd": "^0.2.2",
+    "@peculiar/x509": "^1.13.0",
     "@types/pkijs": "^3.0.1",
     "asn1js": "^3.0.6",
     "class-transformer": "0.5.1",

--- a/packages/mrtd/src/DidCommMrtdApi.ts
+++ b/packages/mrtd/src/DidCommMrtdApi.ts
@@ -9,7 +9,6 @@ import {
   Feature,
 } from '@credo-ts/core'
 
-import { DidCommMrtdService } from './services/DidCommMrtdService'
 import {
   EMrtdDataHandler,
   EMrtdDataRequestHandler,
@@ -20,6 +19,7 @@ import {
 import { Capability } from './models/Capability'
 import { MrtdCapabilities } from './models/MrtdCapabilities'
 import { MrtdProblemReportReason } from './models/ProblemReportReason'
+import { DidCommMrtdService } from './services/DidCommMrtdService'
 
 @injectable()
 export class DidCommMrtdApi {

--- a/packages/mrtd/src/DidCommMrtdModule.ts
+++ b/packages/mrtd/src/DidCommMrtdModule.ts
@@ -1,12 +1,13 @@
+import type { DidCommMrtdModuleConfigOptions } from './config/DidCommMrtdModuleConfig'
 import type { DependencyManager, FeatureRegistry, Module } from '@credo-ts/core'
+
 import { Protocol } from '@credo-ts/core'
 
 import { DidCommMrtdApi } from './DidCommMrtdApi'
-import { DidCommMrtdService } from './services/DidCommMrtdService'
+import { DidCommMrtdModuleConfig } from './config/DidCommMrtdModuleConfig'
 import { DidCommMrtdRole } from './models'
 import { CscaMasterListService, SodVerifierService } from './services'
-
-import { DidCommMrtdModuleConfig, DidCommMrtdModuleConfigOptions } from './config/DidCommMrtdModuleConfig'
+import { DidCommMrtdService } from './services/DidCommMrtdService'
 
 /**
  * Module configuration and registration for DIDComm MRTD.

--- a/packages/mrtd/src/config/DidCommMrtdModuleConfig.ts
+++ b/packages/mrtd/src/config/DidCommMrtdModuleConfig.ts
@@ -1,7 +1,3 @@
-// packages/mrtd/src/DidCommMrtdModuleConfig.ts
-
-import type { InjectionToken } from '@credo-ts/core'
-
 /**
  * Module configuration options for DidCommMrtdModule.
  */

--- a/packages/mrtd/src/models/EMrtdData.ts
+++ b/packages/mrtd/src/models/EMrtdData.ts
@@ -1,3 +1,4 @@
+import type { SodVerification } from './SodVerification'
 import type tsemrtd from '@li0ard/tsemrtd'
 import type { SecurityInfos } from '@li0ard/tsemrtd/dist/asn1/eac'
 import type { CSCAMasterList } from '@li0ard/tsemrtd/dist/asn1/pkd'
@@ -17,7 +18,6 @@ const { COM, DG1, DG2, DG3, DG4, DG5, DG7, DG11, DG12, DG14, DG15, SOD, PKD } =
   require('../esm/bundle.js') as typeof tsemrtd
 
 import { EMrtdDataGroup } from './EMrtdDataGroup'
-import { SodVerification } from './SodVerification'
 
 export type EMrtdData = {
   raw: Record<string, string>

--- a/packages/mrtd/src/services/CscaMasterListService.ts
+++ b/packages/mrtd/src/services/CscaMasterListService.ts
@@ -156,8 +156,9 @@ export class CscaMasterListService {
 
         // Step 2: Extract encapsulated ASN.1 (OCTET STRING) payload
         const eci = signedData.encapContentInfo
-        // @ts-ignore
-        const masterListDER: ArrayBuffer = eci.eContent.valueBlock.valueHex
+
+        const masterListDER = eci.eContent?.valueBlock.valueHex
+        if (!masterListDER) throw new Error('Invalid DER Master List')
 
         // Step 3: Parse Master List
         const mlASN1 = fromBER(masterListDER)

--- a/packages/mrtd/src/services/CscaMasterListService.ts
+++ b/packages/mrtd/src/services/CscaMasterListService.ts
@@ -1,7 +1,8 @@
+import { AgentContext, FileSystem, inject, injectable, InjectionSymbols, type Logger } from '@credo-ts/core'
+import { X509Certificate } from '@peculiar/x509'
 import { fromBER, Sequence, Set } from 'asn1js'
 import { ContentInfo, SignedData, Certificate } from 'pkijs'
-import { X509Certificate } from '@peculiar/x509'
-import { AgentContext, FileSystem, inject, injectable, InjectionSymbols, type Logger } from '@credo-ts/core'
+
 import { DidCommMrtdModuleConfig } from '../config/DidCommMrtdModuleConfig'
 
 /**
@@ -22,7 +23,7 @@ export class CscaMasterListService {
    * @param sourceLocation Path or URL to the Master List LDIF file.
    * @throws If the location is not defined.
    */
-  constructor(@inject(AgentContext) private agentContext: AgentContext) {
+  public constructor(@inject(AgentContext) private agentContext: AgentContext) {
     this.logger = agentContext.config.logger
   }
 
@@ -117,7 +118,7 @@ export class CscaMasterListService {
 
     let match: RegExpExecArray | null
     while ((match = regex.exec(ldifContent)) !== null) {
-      let b64 = match[1].replace(/\r/g, '').replace(/\n/g, '').replace(/ /g, '')
+      const b64 = match[1].replace(/\r/g, '').replace(/\n/g, '').replace(/ /g, '')
       try {
         const buf = Buffer.from(b64, 'base64')
         if (buf.length > 10000) {

--- a/packages/mrtd/src/services/DidCommMrtdService.ts
+++ b/packages/mrtd/src/services/DidCommMrtdService.ts
@@ -10,6 +10,7 @@ import {
   MrzDataReceivedEvent,
   MrzDataRequestedEvent,
 } from '../DidCommMrtdEvents'
+import { DidCommMrtdModuleConfig } from '../config/DidCommMrtdModuleConfig'
 import {
   EMrtdDataMessage,
   EMrtdDataRequestMessage,
@@ -18,10 +19,10 @@ import {
   MrzDataRequestMessage,
 } from '../messages'
 import { parseEMrtdData } from '../models'
-
-import { CscaMasterListService, SodVerifierService } from '.'
-import { DidCommMrtdModuleConfig } from '../config/DidCommMrtdModuleConfig'
 import { SodVerification } from '../models/SodVerification'
+
+import { CscaMasterListService } from './CscaMasterListService'
+import { SodVerifierService } from './SodVerifierService'
 
 @scoped(Lifecycle.ContainerScoped)
 export class DidCommMrtdService {

--- a/packages/mrtd/src/services/SodVerifierService.ts
+++ b/packages/mrtd/src/services/SodVerifierService.ts
@@ -1,10 +1,12 @@
-import { fromBER, Sequence, OctetString, ObjectIdentifier, Integer } from 'asn1js'
-import { Certificate, ContentInfo, SignedData } from 'pkijs'
-import { X509Certificate, X509ChainBuilder } from '@peculiar/x509'
-import * as crypto from 'crypto'
 import { ConsoleLogger, inject, injectable, LogLevel, type Logger } from '@credo-ts/core'
-import { CscaMasterListService } from './CscaMasterListService'
+import { X509Certificate, X509ChainBuilder } from '@peculiar/x509'
+import { fromBER, Sequence, OctetString, ObjectIdentifier, Integer } from 'asn1js'
+import * as crypto from 'crypto'
+import { Certificate, ContentInfo, SignedData } from 'pkijs'
+
 import { SodVerification } from '../models/SodVerification'
+
+import { CscaMasterListService } from './CscaMasterListService'
 
 /**
  * Utility class to verify SOD (EF.SOD) authenticity and integrity.
@@ -18,7 +20,7 @@ export class SodVerifierService {
   /**
    * @param trustAnchors List of X509 CSCA certificates for signature verification.
    */
-  constructor(@inject(CscaMasterListService) private readonly mlService: CscaMasterListService) {
+  public constructor(@inject(CscaMasterListService) private readonly mlService: CscaMasterListService) {
     this.logger = new ConsoleLogger(LogLevel.info)
     this.trustAnchors = []
   }

--- a/packages/mrtd/src/services/SodVerifierService.ts
+++ b/packages/mrtd/src/services/SodVerifierService.ts
@@ -60,8 +60,11 @@ export class SodVerifierService {
       this.logger.debug(`[SodVerifierService] verifySod - SignedData ${JSON.stringify(signedData, null, 2)}`)
 
       this.logger.info('[SodVerifierService] verifySod - Step 4: Extracting encapsulated LDS Security Object')
-      // @ts-ignore
-      const ldsContent: ArrayBuffer = signedData.encapContentInfo.eContent.valueBlock.valueHex
+
+      const ldsContent = signedData.encapContentInfo.eContent?.valueBlock.valueHex
+      if (!ldsContent) {
+        throw new Error('Invalid LDS content in SOD')
+      }
       const ldsASN1 = fromBER(ldsContent)
       if (ldsASN1.offset === -1) throw new Error('Invalid LDS ASN.1 in SOD content')
 

--- a/packages/mrtd/src/services/SodVerifierService.ts
+++ b/packages/mrtd/src/services/SodVerifierService.ts
@@ -1,4 +1,4 @@
-import { ConsoleLogger, inject, injectable, LogLevel, type Logger } from '@credo-ts/core'
+import { inject, injectable, InjectionSymbols, type Logger } from '@credo-ts/core'
 import { X509Certificate, X509ChainBuilder } from '@peculiar/x509'
 import { fromBER, Sequence, OctetString, ObjectIdentifier, Integer } from 'asn1js'
 import * as crypto from 'crypto'
@@ -20,8 +20,11 @@ export class SodVerifierService {
   /**
    * @param trustAnchors List of X509 CSCA certificates for signature verification.
    */
-  public constructor(@inject(CscaMasterListService) private readonly mlService: CscaMasterListService) {
-    this.logger = new ConsoleLogger(LogLevel.info)
+  public constructor(
+    @inject(CscaMasterListService) private readonly mlService: CscaMasterListService,
+    @inject(InjectionSymbols.Logger) logger: Logger,
+  ) {
+    this.logger = logger
     this.trustAnchors = []
   }
 

--- a/packages/mrtd/tests/DidCommMrtdService.test.ts
+++ b/packages/mrtd/tests/DidCommMrtdService.test.ts
@@ -13,9 +13,9 @@ import {
 } from '@credo-ts/core'
 
 import { MrtdEventTypes } from '../src/DidCommMrtdEvents'
-import { DidCommMrtdService } from '../src/services/DidCommMrtdService'
 import { EMrtdDataMessage } from '../src/messages'
 import { MrtdProblemReportReason } from '../src/models'
+import { DidCommMrtdService } from '../src/services/DidCommMrtdService'
 
 import { setupAgent } from './utils/agent'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@2060.io/ffi-napi@4.0.9", "@2060.io/ffi-napi@^4.0.9":
+"@2060.io/ffi-napi@^4.0.9":
   version "4.0.9"
   resolved "https://registry.yarnpkg.com/@2060.io/ffi-napi/-/ffi-napi-4.0.9.tgz#194fca2132932ba02e62d716c786d20169b20b8d"
   integrity sha512-JfVREbtkJhMXSUpya3JCzDumdjeZDCKv4PemiWK+pts5CYgdoMidxeySVlFeF5pHqbBpox4I0Be7sDwAq4N0VQ==
@@ -999,7 +999,18 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.2"
 
-"@jest/types@^26.6.2", "@jest/types@^29.5.0", "@jest/types@^29.6.3":
+"@jest/types@^26.6.2":
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.2.tgz#bef5a532030e1d88a2f5a6d933f84e97226ed48e"
+  integrity sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.6.3.tgz#1131f8cf634e7e84c5e77bab12f052af585fba59"
   integrity sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==
@@ -1145,6 +1156,27 @@
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
+"@peculiar/asn1-cms@^2.3.15", "@peculiar/asn1-cms@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-cms/-/asn1-cms-2.4.0.tgz#327c459460d6fa6d3e582208784543a4b7aeaa73"
+  integrity sha512-TJvw5Tna/txvzzwnKUlCFd6zIz4R7qysHCaU6M2oe/MUT6EkvJDOzGGNY0hdjJYpuuHoqanQbIqEBhSLSWe1Tg==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    "@peculiar/asn1-x509-attr" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-csr@^2.3.15":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.4.0.tgz#2182dd35061b03930bdc10034b3d548c38cf1264"
+  integrity sha512-9yQz0hQ9ynGr/I1X1v64QQGfRMbviHXyqY07cy69UzXa8s4ayCKx/TncU6lDWcTKs7P/X/AEcuJcG7Xbw0cl1A==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
 "@peculiar/asn1-csr@^2.3.8":
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-csr/-/asn1-csr-2.3.13.tgz#0a40e2dead26d5bfff636a64147998f7ae2b8c4b"
@@ -1154,6 +1186,16 @@
     "@peculiar/asn1-x509" "^2.3.13"
     asn1js "^3.0.5"
     tslib "^2.6.2"
+
+"@peculiar/asn1-ecc@^2.3.15":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-ecc/-/asn1-ecc-2.4.0.tgz#e21f87b12a0be3e57d6a914e576b6d10aa4a35d4"
+  integrity sha512-fJiYUBCJBDkjh347zZe5H81BdJ0+OGIg0X9z06v8xXUoql3MFeENUX0JsjCaVaU9A0L85PefLPGYkIoGpTnXLQ==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
 
 "@peculiar/asn1-ecc@^2.3.8":
   version "2.3.13"
@@ -1177,6 +1219,18 @@
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
+"@peculiar/asn1-pfx@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pfx/-/asn1-pfx-2.4.0.tgz#654327b736ca24f585e5b687d8a3f661dc60d0b1"
+  integrity sha512-fhpeoJ6T4nCLWT5tt3Un+BbyM1lLFnGXcRC2Ioe5ra2I0yptdjw05j20rV8BlUVzPIvUYpatq6joMQKe3ibh0w==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.4.0"
+    "@peculiar/asn1-pkcs8" "^2.4.0"
+    "@peculiar/asn1-rsa" "^2.4.0"
+    "@peculiar/asn1-schema" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
 "@peculiar/asn1-pkcs8@^2.3.13":
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.13.tgz#eefe42766ebd3dabfc6b14d942d0d5799ee9f04c"
@@ -1186,6 +1240,30 @@
     "@peculiar/asn1-x509" "^2.3.13"
     asn1js "^3.0.5"
     tslib "^2.6.2"
+
+"@peculiar/asn1-pkcs8@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.4.0.tgz#53c3c8dd2e99a2499f4a1e1639b8b4284f0b6a46"
+  integrity sha512-4r2LtsAM0HWXLxetGTYKyBumky7W6C1EuiOctqhl7zFK5MHjiZ+9WOeaoeTPR1g3OEoeG7KEWIkaUOyRH4ojTw==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
+"@peculiar/asn1-pkcs9@^2.3.15":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.4.0.tgz#6ceb3041358b31bd2b3f68545ec1aefa3ad1af43"
+  integrity sha512-D7paqEVpu9wuWuClMN+vR5cqJWJITNPaMoa9R+FmkJ8ywF9UaS2JFI0RYclKILNoLdLg1N4eUCoJvM+ubsIIZQ==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.4.0"
+    "@peculiar/asn1-pfx" "^2.4.0"
+    "@peculiar/asn1-pkcs8" "^2.4.0"
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    "@peculiar/asn1-x509-attr" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
 
 "@peculiar/asn1-pkcs9@^2.3.8":
   version "2.3.13"
@@ -1211,6 +1289,16 @@
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
+"@peculiar/asn1-rsa@^2.3.15", "@peculiar/asn1-rsa@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-rsa/-/asn1-rsa-2.4.0.tgz#da988b4b0a8d97f7f515f1a8f583accb43a475e7"
+  integrity sha512-6PP75voaEnOSlWR9sD25iCQyLgFZHXbmxvUfnnDcfL6Zh5h2iHW38+bve4LfH7a60x7fkhZZNmiYqAlAff9Img==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
 "@peculiar/asn1-schema@^2.3.13", "@peculiar/asn1-schema@^2.3.8":
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz#ec8509cdcbc0da3abe73fd7e690556b57a61b8f4"
@@ -1219,6 +1307,15 @@
     asn1js "^3.0.5"
     pvtsutils "^1.3.5"
     tslib "^2.6.2"
+
+"@peculiar/asn1-schema@^2.3.15", "@peculiar/asn1-schema@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-schema/-/asn1-schema-2.4.0.tgz#e3aa7917d433b4c3fcfa1fcb57eac233b1c38787"
+  integrity sha512-umbembjIWOrPSOzEGG5vxFLkeM8kzIhLkgigtsOrfLKnuzxWxejAcUX+q/SoZCdemlODOcr5WiYa7+dIEzBXZQ==
+  dependencies:
+    asn1js "^3.0.6"
+    pvtsutils "^1.3.6"
+    tslib "^2.8.1"
 
 "@peculiar/asn1-x509-attr@^2.3.13":
   version "2.3.13"
@@ -1230,6 +1327,16 @@
     asn1js "^3.0.5"
     tslib "^2.6.2"
 
+"@peculiar/asn1-x509-attr@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.4.0.tgz#f68346bf24ee2691682e5e58b5116e81cb91e280"
+  integrity sha512-Tr5Zi+wcE2sfR0gKRvsPwXoA1U8CuDnwiFbxCS+5Z1Nck9zlHj86+4/EZhwucjKXwPEHk1ekhqb3iwISY/+E/w==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    "@peculiar/asn1-x509" "^2.4.0"
+    asn1js "^3.0.6"
+    tslib "^2.8.1"
+
 "@peculiar/asn1-x509@^2.3.13", "@peculiar/asn1-x509@^2.3.8":
   version "2.3.13"
   resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.3.13.tgz#3616fb879b61f1f161a61660ca92f6fe4107af7a"
@@ -1240,6 +1347,16 @@
     ipaddr.js "^2.1.0"
     pvtsutils "^1.3.5"
     tslib "^2.6.2"
+
+"@peculiar/asn1-x509@^2.3.15", "@peculiar/asn1-x509@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/asn1-x509/-/asn1-x509-2.4.0.tgz#ca8ec0d409678e1a47bc324c3dc739085186123f"
+  integrity sha512-F7mIZY2Eao2TaoVqigGMLv+NDdpwuBKU1fucHPONfzaBS4JXXCNCmfO0Z3dsy7JzKGqtDcYC1mr9JjaZQZNiuw==
+  dependencies:
+    "@peculiar/asn1-schema" "^2.4.0"
+    asn1js "^3.0.6"
+    pvtsutils "^1.3.6"
+    tslib "^2.8.1"
 
 "@peculiar/json-schema@^1.1.12":
   version "1.1.12"
@@ -1275,6 +1392,23 @@
     reflect-metadata "^0.2.2"
     tslib "^2.6.2"
     tsyringe "^4.8.0"
+
+"@peculiar/x509@^1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@peculiar/x509/-/x509-1.13.0.tgz#c404d075aac4dfa52320e0a1cb11268efacdb9dd"
+  integrity sha512-r9BOb1GZ3gx58Pog7u9x70spnHlCQPFm7u/ZNlFv+uBsU7kTDY9QkUD+l+X0awopDuCK1fkH3nEIZeMDSG/jlw==
+  dependencies:
+    "@peculiar/asn1-cms" "^2.3.15"
+    "@peculiar/asn1-csr" "^2.3.15"
+    "@peculiar/asn1-ecc" "^2.3.15"
+    "@peculiar/asn1-pkcs9" "^2.3.15"
+    "@peculiar/asn1-rsa" "^2.3.15"
+    "@peculiar/asn1-schema" "^2.3.15"
+    "@peculiar/asn1-x509" "^2.3.15"
+    pvtsutils "^1.3.6"
+    reflect-metadata "^0.2.2"
+    tslib "^2.8.1"
+    tsyringe "^4.10.0"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -1649,12 +1783,19 @@
     "@types/node" "*"
     form-data "^4.0.0"
 
-"@types/node@*", "@types/node@^18.0.0", "@types/node@^20.11.16":
+"@types/node@*", "@types/node@^18.0.0":
   version "18.19.50"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.50.tgz#8652b34ee7c0e7e2004b3f08192281808d41bf5a"
   integrity sha512-xonK+NRrMBRtkL1hVCc3G+uXtjh1Al4opBLjqVmipe5ZAaBYWW6cNAiBVZ1BvmkBhep698rP3UM3aRAdSALuhg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@^20.11.16":
+  version "20.19.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.10.tgz#8bee5d6fa97221d50d767fa5707a3dd6503e8f19"
+  integrity sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==
+  dependencies:
+    undici-types "~6.21.0"
 
 "@types/pkijs@^3.0.1":
   version "3.0.1"
@@ -1726,6 +1867,13 @@
   version "21.0.3"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-21.0.3.tgz#815e30b786d2e8f0dcd85fd5bcf5e1a04d008f15"
   integrity sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==
+
+"@types/yargs@^15.0.0":
+  version "15.0.19"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.19.tgz#328fb89e46109ecbdb70c295d96ff2f46dfd01b9"
+  integrity sha512-2XUaGVmyQjgyAZldf0D0c14vvo/yv0MhQBSTJcejMMaitsn3nxCB6TmH4G0ZQf+uxROOa9mpanoSm8h6SG/1ZA==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yargs@^17.0.8":
   version "17.0.33"
@@ -2119,15 +2267,6 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
-  integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==
-  dependencies:
-    follow-redirects "^1.15.6"
-    form-data "^4.0.4"
-    proxy-from-env "^1.1.0"
-
 b64-lite@^1.3.1, b64-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/b64-lite/-/b64-lite-1.4.0.tgz#e62442de11f1f21c60e38b74f111ac0242283d3d"
@@ -2358,14 +2497,6 @@ bytestreamjs@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/bytestreamjs/-/bytestreamjs-2.0.1.tgz#a32947c7ce389a6fa11a09a9a563d0a45889535e"
   integrity sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==
-
-call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
-  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
-  dependencies:
-    es-errors "^1.3.0"
-    function-bind "^1.1.2"
 
 call-bind@^1.0.2, call-bind@^1.0.5, call-bind@^1.0.6, call-bind@^1.0.7:
   version "1.0.7"
@@ -2822,15 +2953,6 @@ dot-prop@^5.1.0:
   dependencies:
     is-obj "^2.0.0"
 
-dunder-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
-  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
-  dependencies:
-    call-bind-apply-helpers "^1.0.1"
-    es-errors "^1.3.0"
-    gopd "^1.2.0"
-
 dynamic-dedupe@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/dynamic-dedupe/-/dynamic-dedupe-0.3.0.tgz#06e44c223f5e4e94d78ef9db23a6515ce2f962a1"
@@ -2969,11 +3091,6 @@ es-define-property@^1.0.0:
   dependencies:
     get-intrinsic "^1.2.4"
 
-es-define-property@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
-  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
-
 es-errors@^1.2.1, es-errors@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
@@ -2986,13 +3103,6 @@ es-object-atoms@^1.0.0:
   dependencies:
     es-errors "^1.3.0"
 
-es-object-atoms@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
-  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
-  dependencies:
-    es-errors "^1.3.0"
-
 es-set-tostringtag@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.0.3.tgz#8bb60f0a440c2e4281962428438d58545af39777"
@@ -3001,16 +3111,6 @@ es-set-tostringtag@^2.0.3:
     get-intrinsic "^1.2.4"
     has-tostringtag "^1.0.2"
     hasown "^2.0.1"
-
-es-set-tostringtag@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
-  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
-  dependencies:
-    es-errors "^1.3.0"
-    get-intrinsic "^1.2.6"
-    has-tostringtag "^1.0.2"
-    hasown "^2.0.2"
 
 es-shim-unscopables@^1.0.0, es-shim-unscopables@^1.0.2:
   version "1.0.2"
@@ -3566,11 +3666,6 @@ flatted@^3.2.9:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
   integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
-follow-redirects@^1.15.6:
-  version "1.15.9"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
-
 for-each@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
@@ -3593,17 +3688,6 @@ form-data@^4.0.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
-    mime-types "^2.1.12"
-
-form-data@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.4.tgz#784cdcce0669a9d68e94d11ac4eea98088edd2c4"
-  integrity sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
     mime-types "^2.1.12"
 
 format-util@^1.0.5:
@@ -3711,34 +3795,10 @@ get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@
     has-symbols "^1.0.3"
     hasown "^2.0.0"
 
-get-intrinsic@^1.2.6:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
-  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
-  dependencies:
-    call-bind-apply-helpers "^1.0.2"
-    es-define-property "^1.0.1"
-    es-errors "^1.3.0"
-    es-object-atoms "^1.1.1"
-    function-bind "^1.1.2"
-    get-proto "^1.0.1"
-    gopd "^1.2.0"
-    has-symbols "^1.1.0"
-    hasown "^2.0.2"
-    math-intrinsics "^1.1.0"
-
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
-
-get-proto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
-  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
-  dependencies:
-    dunder-proto "^1.0.1"
-    es-object-atoms "^1.0.0"
 
 get-stream@^6.0.0:
   version "6.0.1"
@@ -3850,11 +3910,6 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-gopd@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
-  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
-
 graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -3896,11 +3951,6 @@ has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
-
-has-symbols@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
-  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
 has-tostringtag@^1.0.0, has-tostringtag@^1.0.2:
   version "1.0.2"
@@ -4942,11 +4992,6 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
-math-intrinsics@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
-  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
-
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -5487,11 +5532,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -6281,6 +6321,13 @@ tslib@^2.6.3, tslib@^2.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
+tsyringe@^4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/tsyringe/-/tsyringe-4.10.0.tgz#d0c95815d584464214060285eaaadd94aa03299c"
+  integrity sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==
+  dependencies:
+    tslib "^1.9.3"
+
 tsyringe@^4.8.0:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/tsyringe/-/tsyringe-4.8.0.tgz#d599651b36793ba872870fee4f845bd484a5cac1"
@@ -6405,6 +6452,11 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@^5.21.2:
   version "5.28.4"


### PR DESCRIPTION
Now that this repo CI is fixed, we found some issues in validation that are preventing us from releasing a ner MRTD module version. In this PR there are several fixes in formatting and dependencies to make it work again.

Although most of them represent minor changes, there is a particular one that could cause issues: I've replaced `crypto.createHash` call to `Hasher.hash` in SodVerifier, because crypto is a node native module and might produce build errors when installing in React Native (even if it is not used). Credo's embedded hasher works great, but currently only supports SHA-1 and SHA-256. Therefore, if there are passports that are already using SHA-512, we won't support them unless we add support for it within Credo (shouldn't be so hard, I think we can include it in the next minor release if needed).

@gabrielmatau79 can you do some tests with the passport data we have and check if it works properly?