### PR TITLE
refactor: expose all services via mrtd package index

### DIFF
--- a/packages/mrtd/src/index.ts
+++ b/packages/mrtd/src/index.ts
@@ -1,6 +1,6 @@
 export { DidCommMrtdApi } from './DidCommMrtdApi'
 export { DidCommMrtdModule } from './DidCommMrtdModule'
-export { DidCommMrtdService } from './services/DidCommMrtdService'
 export * from './DidCommMrtdEvents'
 export * from './models'
 export * from './messages'
+export * from './services'

--- a/packages/mrtd/tests/SodVerifierService.test.ts
+++ b/packages/mrtd/tests/SodVerifierService.test.ts
@@ -3,7 +3,7 @@ import { X509Certificate } from '@peculiar/x509'
 import { promises as fs } from 'fs'
 import path from 'path'
 
-import { SodVerifierService } from '../src/services'
+import { SodVerifierService } from '../src'
 
 import { MockCscaMasterListService } from './__mocks__/CscaMasterListService.mock'
 


### PR DESCRIPTION
This PR updates the mrtd module to explicitly expose all public services through the package entrypoint