### PR TITLE
fix: remove duplicate save in the processRequest

### DIFF
--- a/packages/shorten-url/src/DidCommShortenUrlService.ts
+++ b/packages/shorten-url/src/DidCommShortenUrlService.ts
@@ -68,7 +68,6 @@ export class DidCommShortenUrlService {
       shortUrlSlug: inboundMessageContext.message.shortUrlSlug,
     })
     await this.repository.save(inboundMessageContext.agentContext, record)
-    await this.repository.save(inboundMessageContext.agentContext, record)
 
     this.eventEmitter.emit<DidCommRequestShortenedUrlReceivedEvent>(inboundMessageContext.agentContext, {
       type: DidCommShortenUrlEventTypes.DidCommRequestShortenedUrlReceived,


### PR DESCRIPTION
The DidCommShortenUrlRecord of the processRequest was being saved twice and this caused an error has been resolved.