### PR TITLE
fix: Fix shorten-url message response missing threadId

### DIFF
--- a/packages/shorten-url/src/messages/ShortenedUrlMessage.ts
+++ b/packages/shorten-url/src/messages/ShortenedUrlMessage.ts
@@ -13,6 +13,7 @@ export class ShortenedUrlMessage extends AgentMessage {
     super()
     if (options) {
       this.id = options.id ?? this.generateId()
+      this.setThread({ threadId: options.id })
       this.shortenedUrl = options.shortenedUrl
       this.expiresTime = options.expiresTime
     }

--- a/packages/shorten-url/test/Messages.test.ts
+++ b/packages/shorten-url/test/Messages.test.ts
@@ -108,6 +108,7 @@ describe('DIDComm Shorten URL Message models', () => {
       expect(toDidCommV2(msg)).toEqual({
         type: 'https://didcomm.org/shorten-url/1.0/shortened-url',
         id: msg.id,
+        thid: 'rec-123',
         body: {
           shortened_url: 'https://test.io/a1b2',
           expires_time: expiresAt.toISOString(),


### PR DESCRIPTION
## Summary

- Fix missing DIDComm threadId on ShortenedUrlMessage.
- Revert the threadId assign using the existing recordId.